### PR TITLE
Release Prep: Merge dev into alpha (dependency fixes & export improvements)

### DIFF
--- a/docs/sections/Development/process.rst
+++ b/docs/sections/Development/process.rst
@@ -17,23 +17,27 @@ Pushes and Merge Workflow
 -------------------------
 
 1. **Feature Branch Development**:
+
    - Each developer creates a `featureXXX` branch to work on their feature.
    - When the feature is complete, a pull request (PR) is made to merge `featureXXX` into `dev`.
    - GitHub Actions will automatically run tests and generate a coverage report on the PR.
    - If the tests pass, the feature can be merged into `dev`; if tests fail, the PR cannot be merged until issues are resolved.
 
 2. **Development Integration on `dev`**:
+
    - Multiple `featureXXX` branches may be merged into `dev` concurrently.
    - This branch is intended for integrating and testing new features collectively before staging.
    - When `dev` reaches a stable state with passing tests, it can proceed to the `alpha` branch.
 
 3. **Alpha Testing on `alpha`**:
+
    - The `dev` branch is merged into `alpha` for pre-release validation.
    - GitHub Actions re-runs tests and generates a coverage report to verify stability.
    - If all tests pass, the version is tagged on `alpha`, marking it as ready for release.
    - Build and installation tests are also performed to ensure the package can be installed correctly.
 
 4. **Production Release on `master`**:
+
    - The fully tested and working code is merged into `master`.
    - The version is tagged on `master` to mark it as a stable release.
    - Once there is a tag, a release is created on GitHub, documenting the changes.

--- a/mloptimizer/domain/hyperspace/hyperspace.py
+++ b/mloptimizer/domain/hyperspace/hyperspace.py
@@ -87,12 +87,18 @@ class HyperparameterSpace:
         """
         try:
             # Load JSON data from the file
-            with open(file_path, 'r') as file:
-                json_data = json.load(file)
+            with open(file_path, 'r', encoding='utf-8') as file:
+                json_text = file.read()  # Read raw JSON string
+                json_data = json.loads(json_text)  # Try to parse it
+
         except FileNotFoundError:
             raise FileNotFoundError(f"The file {file_path} does not exist")
         except json.JSONDecodeError as e:
-            raise json.JSONDecodeError("The file {file_path} is not a valid JSON file", json_data, e.pos)
+            raise json.JSONDecodeError(
+                f"The file '{file_path}' is not a valid JSON file: {e.msg}",
+                doc=json_text,  # The original JSON string
+                pos=e.pos  # The error position
+            )
 
         # Extract fixed hyperparams, just a dictionary
         fixed_hyperparams = json_data['fixed_hyperparams']

--- a/mloptimizer/domain/optimization/genetic_algorithm.py
+++ b/mloptimizer/domain/optimization/genetic_algorithm.py
@@ -126,11 +126,13 @@ class GeneticAlgorithm:
         population_df = self.population_2_df()
         df = population_df[hyperparam_names]
         g = plotly_search_space(df)
-        g.write_html(os.path.join(self.tracker.graphics_path, "search_space.html"))
+        g.write_html(os.path.join(self.tracker.graphics_path, "search_space.html"),
+                     full_html=False, include_plotlyjs='cdn')
         plt.close()
 
         g2 = plotly_logbook(logbook, population_df)
-        g2.write_html(os.path.join(self.tracker.graphics_path, "logbook.html"))
+        g2.write_html(os.path.join(self.tracker.graphics_path, "logbook.html"),
+                     full_html=False, include_plotlyjs='cdn')
         plt.close()
 
     def custom_run(self, population_size: int, n_generations: int, cxpb: float = 0.5, mutation_prob: float = 0.5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ kaleido
 numpy
 pandas>=1.5.3
 plotly>=5.15.0
+matplotlib<3.10.0
 python-dateutil>=2.8.1
 pytz>=2022.7.1
 scikit-learn>=1.2.1,<=1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas>=1.5.3
 plotly>=5.15.0
 python-dateutil>=2.8.1
 pytz>=2022.7.1
-scikit-learn>=1.2.1
+scikit-learn>=1.2.1,<=1.5.2
 scipy>=1.10.0
 seaborn==0.12.2
 six>=1.15.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ pytest-cov
 pytest-mock
 python-dateutil>=2.8.1
 pytz>=2022.7.1
-scikit-learn>=1.2.1
+scikit-learn>=1.2.1,<=1.5.2
 scipy>=1.10.0
 seaborn==0.12.2
 six>=1.15.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,7 @@ mlflow
 numpy
 pandas>=1.5.3
 plotly>=5.15.0
+matplotlib<3.10.0
 pytest-cov
 pytest-mock
 python-dateutil>=2.8.1

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -7,6 +7,7 @@ keras>=2.13.1rc0
 numpy
 pandas>=1.5.3
 plotly>=5.15.0
+matplotlib<3.10.0
 pytest-cov
 python-dateutil>=2.8.1
 pytz>=2022.7.1

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -10,7 +10,7 @@ plotly>=5.15.0
 pytest-cov
 python-dateutil>=2.8.1
 pytz>=2022.7.1
-scikit-learn>=1.2.1
+scikit-learn>=1.2.1,<=1.5.2
 scipy>=1.10.0
 seaborn==0.12.2
 six>=1.15.0


### PR DESCRIPTION
## 🔀 PR: Merge `dev` into `alpha`

This PR brings recent changes from `dev` into `alpha` as part of the standard release process.

### ✏️ Changes

- Enforced lower versions for:
  - `matplotlib < 1.10` (fixes plot utility failures)
  - `scikit-learn < 1.6` (resolves compatibility issues)
- Reduced size of `plotly` HTML exports
- Fixed minor documentation issues
- Handled JSON decoding error

### ✅ Next Steps

- Validate on `alpha`
- If stable, open PR from `alpha` → `master`